### PR TITLE
Hyphen issue - UR-77 is fixed

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -146,7 +146,7 @@ $(document).ready(function() {
       a.attr("data-name", nameClean(trendItem));
 
       // Providing the initial button text
-      a.text(nameClean(trendItem));
+      a.text(nameUnclean(trendItem));
 
       $newRow.append(a);
       $("#trend-list").append($newRow);
@@ -291,7 +291,7 @@ $(document).ready(function() {
       a.attr("data-name", nameClean(foodItem));
 
       // Providing the initial button text
-      a.text(nameClean(foodItem));
+      a.text(nameUnclean(foodItem));
 
       $newDiv.append(a);
       $("#food-list").append($newDiv);


### PR DESCRIPTION
Hyphens are MOSTLY removed from Trending and Food items pulled from Firebase.  There are still some issues with very long names and other side cases that perhaps had some hyphens in them to begin with, but at this point, simple two-word items that had hyphens before, do not have them anymore.   